### PR TITLE
[FEAT] JWT 토큰 검증 결과를 enum으로 등록 및 관련 로직 수정

### DIFF
--- a/backend/airbnb-clone/src/main/java/com/GPOslo/airbnbclone/domain/auth/service/AuthService.java
+++ b/backend/airbnb-clone/src/main/java/com/GPOslo/airbnbclone/domain/auth/service/AuthService.java
@@ -17,6 +17,7 @@ import com.GPOslo.airbnbclone.global.jwt.CustomEmailPasswordAuthToken;
 import com.GPOslo.airbnbclone.global.jwt.TokenProvider;
 import com.GPOslo.airbnbclone.global.jwt.domain.RefreshToken;
 import com.GPOslo.airbnbclone.global.jwt.domain.RefreshTokenRepository;
+import com.GPOslo.airbnbclone.global.jwt.domain.TokenStatus;
 import com.GPOslo.airbnbclone.global.jwt.dto.TokenDTO;
 import com.GPOslo.airbnbclone.global.jwt.dto.TokenReqDTO;
 import lombok.RequiredArgsConstructor;
@@ -88,13 +89,13 @@ public class AuthService {
         String originAccessToken = tokenRequestDto.getAccessToken();
         String originRefreshToken = tokenRequestDto.getRefreshToken();
 
-        int refreshTokenFlag = tokenProvider.validateToken(originRefreshToken);
+        TokenStatus refreshTokenFlag = tokenProvider.validateToken(originRefreshToken);
 
         log.debug("refreshTokenFlag = {}", refreshTokenFlag);
 
-        if(refreshTokenFlag == -1) {
+        if(refreshTokenFlag == TokenStatus.WRONG_TOKEN) {
             throw new BizException(JwtExceptionType.BAD_TOKEN);
-        } else if(refreshTokenFlag == 2) {
+        } else if(refreshTokenFlag == TokenStatus.EXPIRED_TOKEN) {
             throw new BizException(JwtExceptionType.REFRESH_TOKEN_EXPIRED);
         }
 

--- a/backend/airbnb-clone/src/main/java/com/GPOslo/airbnbclone/global/jwt/JwtFilter.java
+++ b/backend/airbnb-clone/src/main/java/com/GPOslo/airbnbclone/global/jwt/JwtFilter.java
@@ -1,5 +1,6 @@
 package com.GPOslo.airbnbclone.global.jwt;
 
+import com.GPOslo.airbnbclone.global.jwt.domain.TokenStatus;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
@@ -29,6 +30,21 @@ public class JwtFilter extends OncePerRequestFilter {
                                     FilterChain filterChain)
             throws ServletException, IOException {
 
+        String token = resolveToken(request);
+        log.debug("token = {}", token);
+
+        if(StringUtils.hasText(token)) {
+            final TokenStatus flag = tokenProvider.validateToken(token);
+
+            log.debug("flag = {}", flag);
+            if(flag == TokenStatus.VALID_TOKEN) {
+                this.setAuthentication(token);
+            } else if (flag == TokenStatus.EXPIRED_TOKEN) {
+                // 클라이언트가 reissue 요청을 하도록 약속된 JSON 값을 전달 해야한다.
+            } else { // (flag == TokenStatus.WRONG_TOKEN) {
+
+            }
+        }
 
         filterChain.doFilter(request, response);
 

--- a/backend/airbnb-clone/src/main/java/com/GPOslo/airbnbclone/global/jwt/TokenProvider.java
+++ b/backend/airbnb-clone/src/main/java/com/GPOslo/airbnbclone/global/jwt/TokenProvider.java
@@ -3,6 +3,7 @@ package com.GPOslo.airbnbclone.global.jwt;
 import com.GPOslo.airbnbclone.domain.auth.entity.Authority;
 import com.GPOslo.airbnbclone.global.exception.handler.BizException;
 import com.GPOslo.airbnbclone.global.exception.type.AuthorityExceptionType;
+import com.GPOslo.airbnbclone.global.jwt.domain.TokenStatus;
 import com.GPOslo.airbnbclone.global.jwt.dto.TokenDTO;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
@@ -145,16 +146,16 @@ public class TokenProvider {
         return new CustomEmailPasswordAuthToken(principal, "", authorities);
     }
 
-    public int validateToken(String token) {
+    public TokenStatus validateToken(String token) {
         try {
             Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
-            return 1;
+            return TokenStatus.VALID_TOKEN;
         } catch(ExpiredJwtException e) {
             log.info("만료된 JWT 토큰입니다.");
-            return 2;
+            return TokenStatus.EXPIRED_TOKEN;
         } catch(Exception e) {
             log.info("잘못된 토큰입니다.");
-            return -1;
+            return TokenStatus.WRONG_TOKEN;
         }
     }
 

--- a/backend/airbnb-clone/src/main/java/com/GPOslo/airbnbclone/global/jwt/domain/TokenStatus.java
+++ b/backend/airbnb-clone/src/main/java/com/GPOslo/airbnbclone/global/jwt/domain/TokenStatus.java
@@ -1,0 +1,17 @@
+package com.GPOslo.airbnbclone.global.jwt.domain;
+
+public enum TokenStatus {
+    VALID_TOKEN("VALID_TOKEN"),
+    EXPIRED_TOKEN("EXPIRED_TOKEN"),
+    WRONG_TOKEN("WRONG_TOKEN");
+
+    private String abbreviation;
+
+    TokenStatus(String abbreviation) {
+        this.abbreviation = abbreviation;
+    }
+
+    public String getAbbreviation() {
+        return this.abbreviation;
+    }
+}


### PR DESCRIPTION
JWT 토큰 검증 함수(validateToken())의 반환값의 타입을
int 에서 enum(TokenStatus)으로 수정.
이에 따라, 검증 결과로 로직을 분기하는 코드 내용 수정